### PR TITLE
Fix up vagrant and config.py-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ A Diagram
 Requirements
 ============
 
-    apt-get install postgresql-9.4 postgresql-9.4-postgis-2.1 gdal-bin tilecache
-    apt-get install python-jinja2 python-mapnik
+    apt-get install postgresql-9.4 postgresql-9.4-postgis-2.1 gdal-bin tilecache ttf-mscorefonts-installer
+    apt-get install python-jinja2 python-mapnik python-psycopg2 
+
 
 You'll also need to install
 [Magnacarto](https://github.com/omniscale/magnacarto) into your `$PATH`

--- a/config.py-example
+++ b/config.py-example
@@ -1,6 +1,9 @@
+# Postgres db connection
+postgres_connstring = "dbname='buildmap' user='vagrant'"
+
 # Name of your tilecache_seed binary. If you use tilecache from the .deb,
 # this is without the .py
-tilecache_seed_binary = 'tilecache_seed.py'
+tilecache_seed_binary = 'sudo tilecache_seed'
 
 # A list of source files. The key is the table name to use in Postgres.
 source_files = {'site_plan': '../gis-2016/site-plan.dxf'}


### PR DESCRIPTION
These are the change I had to make to the vagrant file to get this up and running on my mac

Vagrant File:
New debian box to get round grub2 update issue, and be closer to head
adding fonts and psycopg2 installation
patch stupid tilecache exception
nginx file name fix
auto setup postures stuff

config.py-example
add missing connection string
fix tilechace_seed command
