### PR TITLE
NocPlugin: flip import order

### DIFF
--- a/buildmap/plugins/noc/__init__.py
+++ b/buildmap/plugins/noc/__init__.py
@@ -7,8 +7,8 @@ import html
 from typing import Iterator
 from sqlalchemy.sql import text
 from datetime import date
-from .data import LinkType, Switch, LogicalLink, Link
 from .util import unit, get_col
+from .data import LinkType, Switch, LogicalLink, Link
 
 
 class NocPlugin(object):


### PR DESCRIPTION
I was getting the following error

```ERROR:BuildMap:Plugin noc not loaded: cannot import name 'unit' from partially initialized module 'buildmap.plugins.noc' (most likely due to a circular import) (/buildmap/buildmap/plugins/noc/__init__.py)```

flipping the import order seems to fix this and the NocPlugin now runs